### PR TITLE
Update lvg2015 to 2020

### DIFF
--- a/OWLCompare/pom.xml
+++ b/OWLCompare/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>gov.nih.nci.evs</groupId>
   <artifactId>OWLCompare</artifactId>
-  <version>2.0</version>
+  <version>2.1</version>
   <name>OWLCompare</name>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
@@ -18,7 +18,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -41,16 +40,33 @@
 		</plugins>
 	</build>
   <dependencies>
+<!--	  <dependency>-->
+<!--		  <groupId>net.sourceforge.owlapi</groupId>-->
+<!--		  <artifactId>owlapi-distribution</artifactId>-->
+<!--		  <version>4.1.4</version>-->
+<!--	  </dependency>-->
 	  <dependency>
-		  <groupId>net.sourceforge.owlapi</groupId>
-		  <artifactId>owlapi-distribution</artifactId>
-		  <version>4.1.4</version>
+		  <groupId>gov.nih.nci.evs.owl</groupId>
+		  <artifactId>owl2kb</artifactId>
+		  <version>3.1</version>
 	  </dependency>
-
 	  <dependency>
   		<groupId>org.apache.poi</groupId>
   		<artifactId>poi</artifactId>
   		<version>4.1.0</version>
   	</dependency>
   </dependencies>
+
+	<repositories>
+		<repository>
+			<id>nci.maven.public</id>
+			<name>NCI Maven public passthrough</name>
+			<url>https://ncimvn.nci.nih.gov/nexus/content/repositories/public</url>
+		</repository>
+		<repository>
+			<id>nlm.maven.public</id>
+			<name>NLM public repo</name>
+			<url>https://lhc-nexus.nlm.nih.gov/repository/lhc-lexicon-maven-releases</url>
+		</repository>
+	</repositories>
 </project>

--- a/OWLDiff/pom.xml
+++ b/OWLDiff/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.nih.nci.evs.owl</groupId>
 	<artifactId>owldiff</artifactId>
-	<version>2.0.0</version>
+	<version>2.1.0</version>
 	<name>OWLDiff</name>
 	<description>Diff two OWL files</description>
 	<build>
@@ -20,7 +20,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -43,15 +42,15 @@
 		</plugins>
 	</build>
 	<dependencies>
-		<dependency>
-			<groupId>net.sourceforge.owlapi</groupId>
-			<artifactId>owlapi-distribution</artifactId>
-			<version>4.1.4</version>
-		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>net.sourceforge.owlapi</groupId>-->
+<!--			<artifactId>owlapi-distribution</artifactId>-->
+<!--			<version>4.1.4</version>-->
+<!--		</dependency>-->
 		<dependency>
 			<groupId>gov.nih.nci.evs.owl</groupId>
 			<artifactId>owl2kb</artifactId>
-			<version>3.0</version>
+			<version>3.1</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/OWLKb/pom.xml
+++ b/OWLKb/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.nih.nci.evs.owl</groupId>
 	<artifactId>owl2kb</artifactId>
-	<version>3.0</version>
+	<version>3.1</version>
 <!--	<packaging>pom</packaging>-->
 	<name>OWLKb</name>
 	<description>wrapper to owlapi to apply NCI EVS business rules</description>
@@ -26,6 +26,15 @@
 <!--			</resource>-->
 <!--		</resources>-->
 
+		<pluginManagement>
+            <plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<version>3.7.1</version>
+				</plugin>
+			</plugins>
+        </pluginManagement>
 		<plugins>
 
 			<plugin>
@@ -41,7 +50,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>3.7.0</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -84,7 +93,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-install-plugin</artifactId>
-				<version>3.0.0-M1</version>
+				<version>3.1.1</version>
 				<configuration>
 					<groupId>gov.nih.nci.evs.owl</groupId>
 					<artifactId>owl2kb</artifactId>
@@ -123,8 +132,8 @@
 		</dependency>
 		<dependency>
 			<groupId>gov.nih.nlm.nls.lvg</groupId>
-			<artifactId>lvg2010dist</artifactId>
-			<version>0.0.1</version>
+			<artifactId>lvgdist</artifactId>
+			<version>2020.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sourceforge.owlapi</groupId>
@@ -135,20 +144,10 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.17.1</version>
+			<version>2.19.0</version>
 		</dependency>
 
-<!--		<dependency>-->
-<!--			<groupId>net.sourceforge.owlapi</groupId>-->
-<!--			<artifactId>owlapi-osgidistribution</artifactId>-->
-<!--			<version>5.1.16</version>-->
-<!--		</dependency>-->
 
-<!--		<dependency>-->
-<!--			<groupId>jgrapht</groupId>-->
-<!--			<artifactId>jgrapht</artifactId>-->
-<!--			<version>0.6.0</version>-->
-<!--		</dependency>-->
 
 
 		<!-- Reasoner -->
@@ -157,7 +156,11 @@
 			<artifactId>org.semanticweb.hermit</artifactId>
 			<version>1.3.8.4</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-assembly-plugin</artifactId>
+			<version>3.7.0</version>
+		</dependency>
 
 		<!-- Download this jar from https://github.com/bdionne/nci-curator/tags
         Install manually using
@@ -169,4 +172,16 @@
 <!--			<version>0.1.3</version>-->
 <!--		</dependency>-->
 	</dependencies>
+	<repositories>
+		<repository>
+			<id>nci.maven.public</id>
+			<name>NCI Maven public passthrough</name>
+			<url>https://ncimvn.nci.nih.gov/nexus/content/repositories/public</url>
+		</repository>
+		<repository>
+			<id>nlm.maven.public</id>
+			<name>NLM public repo</name>
+			<url>https://lhc-nexus.nlm.nih.gov/repository/lhc-lexicon-maven-releases</url>
+		</repository>
+	</repositories>
 </project>

--- a/OWLScrubber/pom.xml
+++ b/OWLScrubber/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.nih.nci.evs.owl</groupId>
 	<artifactId>owlscrubber</artifactId>
-	<version>2.0.0</version>
+	<version>2.1.0</version>
 	<packaging>jar</packaging>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
@@ -19,7 +19,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -43,10 +42,15 @@
 		</plugins>
 	</build>
 	<dependencies>
+<!--		<dependency>-->
+<!--			<groupId>net.sourceforge.owlapi</groupId>-->
+<!--			<artifactId>owlapi-distribution</artifactId>-->
+<!--			<version>4.1.4</version>-->
+<!--		</dependency>-->
 		<dependency>
-			<groupId>net.sourceforge.owlapi</groupId>
-			<artifactId>owlapi-distribution</artifactId>
-			<version>4.1.4</version>
+			<groupId>gov.nih.nci.evs.owl</groupId>
+			<artifactId>owl2kb</artifactId>
+			<version>3.1</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/OWLSummary/pom.xml
+++ b/OWLSummary/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>gov.nih.nci.evs.owl</groupId>
     <artifactId>owlsummary</artifactId>
-    <version>2.3.0</version>
+    <version>2.4.0</version>
     <build>
 
         <sourceDirectory>src</sourceDirectory>
@@ -19,7 +19,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -28,7 +27,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -55,7 +53,7 @@
     <dependency>
         <groupId>gov.nih.nci.evs.owl</groupId>
         <artifactId>owl2kb</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
         <scope>compile</scope>
     </dependency>
 </dependencies>

--- a/ProtegeKBQA/pom.xml
+++ b/ProtegeKBQA/pom.xml
@@ -3,13 +3,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.nih.nci.evs.owl</groupId>
 	<artifactId>owlnciqa</artifactId>
-	<version>2.1</version>
+	<version>2.2</version>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
+				<version>3.8.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -18,7 +18,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -43,13 +42,31 @@
 	<dependencies>
 		<dependency>
 			<groupId>gov.nih.nlm.nls.lvg</groupId>
-			<artifactId>lvg2010dist</artifactId>
-			<version>0.0.1</version>
+			<artifactId>lvgdist</artifactId>
+			<version>2020.0</version>
+			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>gov.nih.nci.evs.owl</groupId>
 			<artifactId>owl2kb</artifactId>
-			<version>3.0</version>
+			<version>3.1</version>
+		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>org.apache.maven.plugins</groupId>-->
+<!--			<artifactId>maven-assembly-plugin</artifactId>-->
+<!--			<version>3.7.0</version>-->
+<!--		</dependency>-->
+		<dependency>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-compiler-plugin</artifactId>
+			<version>3.8.1</version>
 		</dependency>
 	</dependencies>
+	<repositories>
+		<repository>
+			<id>nci.maven.public</id>
+			<name>NCI Maven public passthrough</name>
+			<url>https://ncimvn.nci.nih.gov/nexus/content/repositories/public</url>
+		</repository>
+	</repositories>
 </project>

--- a/Protege_History_Validation/pom.xml
+++ b/Protege_History_Validation/pom.xml
@@ -28,7 +28,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -55,7 +54,7 @@
     <dependency>
         <groupId>gov.nih.nci.evs.owl</groupId>
         <artifactId>owl2kb</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
         <scope>compile</scope>
     </dependency>
 </dependencies>

--- a/UpdateCUI/pom.xml
+++ b/UpdateCUI/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>gov.nih.nci.evs.owl</groupId>
   <artifactId>UpdateCUI</artifactId>
-  <version>2.1</version>
+  <version>2.2</version>
   <build>
 
 		<sourceDirectory>src</sourceDirectory>
@@ -27,7 +27,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -54,7 +53,7 @@
   	<dependency>
   		<groupId>gov.nih.nci.evs.owl</groupId>
   		<artifactId>owl2kb</artifactId>
-  		<version>3.0</version>
+  		<version>3.1</version>
   	</dependency>
   </dependencies>
 </project>

--- a/ValueSetProduction/pom.xml
+++ b/ValueSetProduction/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.nih.nci.evs.owl</groupId>
 	<artifactId>valuesetproduction</artifactId>
-	<version>2.1</version>
+	<version>2.2</version>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
@@ -18,7 +18,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -44,7 +43,7 @@
 		<dependency>
 			<groupId>gov.nih.nci.evs.owl</groupId>
 			<artifactId>owl2kb</artifactId>
-			<version>3.0</version>
+			<version>3.1</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
lvg2015 depends on Java7, which is out of support and considered vulnerable.  owlkb was updated to use lvg2020 and all dependent applications were updated to use the newer owlkb